### PR TITLE
Release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- 電文仕様K対応: 熱電対ユニット 2PF（`thermocouple_unit` / `ThermocoupleUnitSensor`）
+  - `03033FFF` / `03033F02` / `03033F03` を識別
+  - CH1-3 の熱電対タイプと温度を解析（無効値は `None`）
+- 1ZS / 2DB / 2SL / 2ZS / 2ZU の状態コード（SS）変種を `SENSOR_TYPE` に追記
+
+### Changed
+- 対応電文仕様表記を K に更新（README / overview）
+- 非振動センサーの `info.status` を仕様の状態表に合わせて更新
+  - `00`=正常 / `02`=無線異常 / `03`=センサ異常 / `FF`=RFU
+- アナログメーター読取ユニット 2YT の角度(Min/Max)・補正値の単位を単位なし（`-`）に訂正
+- README / API仕様書に経路別の `timestamp` 型契約を追記
+  - UDP / 未解析は ISO8601 `str`（組み込み向けの正）
+  - `parse_text_line` 成功時は naive `datetime | None`（JSON化時は要文字列化）
+
+### Notes (2.0 candidates)
+- 公開辞書の `timestamp` をすべて ISO8601 `str` に揃える
+  - `parse_text_line` 成功時の `datetime` → `str` への変更を含む破壊的変更
+  - 1.x では型変更しない（現行契約を維持）
+
 ## [1.0.0] - 2026-08-22
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-09-07
+
 ### Added
 - 電文仕様K対応: 熱電対ユニット 2PF（`thermocouple_unit` / `ThermocoupleUnitSensor`）
   - `03033FFF` / `03033F02` / `03033F03` を識別

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## 概要
 
-村田製作所の無線センサユニット（電文仕様I対応）は、UDPパケットでセンサーデータを送信します。
+村田製作所の無線センサユニット（電文仕様K対応）は、UDPパケットでセンサーデータを送信します。
 このライブラリではUDPパケットを受信・解析します。
 
 ## 特徴
@@ -187,20 +187,21 @@ thread = receiver.run_in_thread()
 | vibration_speed | 03031800, 03031801 | 振動センサー（速度） | 1TF | 未 |
 | 3_current | 03031BFF | 防水3電流センサー | 1ZU | 済み |
 | 3_voltage | 03031CFF | 防水3電圧センサー | 1ZV | 済み |
-| 3_contacts | 03031DFF | 防水3接点センサー | 1ZS | 済み |
+| 3_contacts | 03031DFF, 03031D00 | 防水3接点センサー | 1ZS | 済み |
 | water_leak | 03031EFF | 漏水センサー | 2AX | 未 |
 | waterproof_repeater | 0303FEFF | 防水中継機 | 2CL | 済み |
 | plg_duty | 030319FF | PLG Duty比監視ユニット | 2AU | 未 |
-| brake_current_monitor | 03032600 | 無線ブレーキ電流監視ユニット | 2DB | 未 |
+| brake_current_monitor | 03032600, 030326FF | 無線ブレーキ電流監視ユニット | 2DB | 未 |
 | vibration_with_instruction | 03032B00, 03032B01 | 計測指示機能付振動センサー | 2DN | 未 |
 | compact_thermocouple | 030331FF | 小型熱電対ユニット | 2FW | 未 |
-| solar_external_sensor | 03033AFF, 03033A00, 03033A02 | 外部センサ用ソーラーユニット | 2SL | 未 |
+| solar_external_sensor | 03033AFF, 03033A00, 03033A02, 03033A03 | 外部センサ用ソーラーユニット | 2SL | 未 |
 | contact_output | 030330FF | 接点出力ユニット | 2ST | 未 |
 | analog_meter_reader | 030333FF | アナログメーター読取ユニット | 2YT | 未 |
 | vibration_2tf001_speed | 03032F00, 03032F01 | 振動 2TF-001 速度モード/低速回転モード | 2TF-001 | 未 |
 | vibration_2tf001_accel | 03033200, 03033201 | 振動 2TF-001 加速度モード | 2TF-001 | 未 |
-| waterproof_contact_pulse | 030338FF | 防水防塵接点パルスユニット | 2ZS | 済み |
-| waterproof_analog_output | 030339FF | 防水防塵アナログ出力無線化ユニット | 2ZU | 済み |
+| waterproof_contact_pulse | 030338FF, 03033800, 03033802, 03033803 | 防水防塵接点パルスユニット | 2ZS | 済み |
+| waterproof_analog_output | 030339FF, 03033902, 03033903 | 防水防塵アナログ出力無線化ユニット | 2ZU | 済み |
+| thermocouple_unit | 03033FFF, 03033F02, 03033F03 | 熱電対ユニット | 2PF | 済み |
 
 `parse_verified` が「未」のタイプも受信・型判定・クラス生成は可能ですが、主要 values の自動テストが未整備です。本番で厳密に保証したい場合は「済み」タイプを優先するか、実機電文での確認を推奨します。（実機を保有していないため、正式なテストができていません。）
 
@@ -221,7 +222,20 @@ for sensor in get_supported_sensors():
 ## 解析結果のデータ構造
 
 このライブラリは、UDP受信時およびテキスト解析時に、**Pythonの辞書形式**で解析結果を返します。  
-開発者はこの辞書をそのままDB保存・JSON変換・メッセージキュー送信などに利用できます。
+UDP受信および未解析コールバックの辞書は、そのままDB保存・JSON変換・メッセージキュー送信などに利用できます。
+
+### timestamp の型（経路別）
+
+公開辞書の `timestamp` は経路によって型が異なる。1.x では次の契約を維持する。
+
+| 経路 | `timestamp` の型 | 意味 |
+|------|------------------|------|
+| UDP受信（`build_sensor_data`） | `str`（ISO8601） | 受信ホストの壁時計時刻 |
+| 未解析（`build_unparsed_data` デフォルト） | `str`（ISO8601） | 同上 |
+| `parse_text_line` 成功時 | `datetime \| None`（naive） | ログ行に記載された時刻（なければ `None`） |
+| `parse_text_line(..., strict=False)` 未解析 | `datetime \| str \| None` | ログ時刻が取れた場合は `datetime`、それ以外は生成時刻の `str` など |
+
+組み込み向けの正は ISO8601 文字列である。`parse_text_line` の成功結果を JSON 化するときは、`timestamp` が `datetime` の場合に `.isoformat()` などで文字列化すること。
 
 ### UDP受信（MurataReceiver / AsyncMurataReceiver）の例
 
@@ -257,7 +271,7 @@ for sensor in get_supported_sensors():
         "sensor_type_code": "01",               # センサ種別コード（冗長だが info 側にも格納）
         "status": {
             "code": "FF",
-            "description": "固定値(FF)",
+            "description": "RFU",
         },
         "route": ["7FFF"],                      # 経路情報（最後の要素がゲートウェイID）
     },
@@ -338,7 +352,7 @@ print(result["info"])              # MurataSensorBase.info と同等の情報
 
 ```python
 {
-    "timestamp": datetime | None,       # 受信タイムスタンプ（なければ None）
+    "timestamp": datetime | None,       # ログ記載時刻（naive）。なければ None。JSON化時は要文字列化
     "source_ip": str | None,            # 送信元IPアドレス
     "source_port": int | None,          # 送信元ポート番号
     "sensor": MurataSensorBase,         # 解析済みセンサーオブジェクト

--- a/docs/api_specification.md
+++ b/docs/api_specification.md
@@ -56,7 +56,7 @@ def on_unparsed(unparsed_data, addr):
     "parsed": False,
     "raw_data": bytes,
     "addr": tuple,
-    "timestamp": str,
+    "timestamp": str,              # ISO8601（デフォルトは受信ホスト時刻）
     "reason": str,                 # unsupported_sensor_type など
     "sensor_type_code": str | None, # センサ種別コード [tt]
     "sensor_message_code": str | None, # 0303[tt][SS]
@@ -212,7 +212,7 @@ def parse_text_line(line: str, strict: bool = True) -> Dict[str, Any]
 ```python
 {
     'parsed': True,
-    'timestamp': datetime,          # 受信タイムスタンプ（なければNone）
+    'timestamp': datetime | None,   # ログ記載時刻（naive）。なければ None。JSON化時は要文字列化
     'source_ip': str,               # 送信元IPアドレス（なければNone）
     'source_port': int,             # 送信元ポート番号（なければNone）
     'sensor': MurataSensorBase,     # 解析済みセンサーオブジェクト
@@ -229,7 +229,7 @@ def parse_text_line(line: str, strict: bool = True) -> Dict[str, Any]
 ```python
 {
     'parsed': False,
-    'timestamp': datetime | str | None,
+    'timestamp': datetime | str | None,  # ログ時刻または生成時刻の str など
     'source_ip': str | None,
     'source_port': int | None,
     'raw_data': bytes,
@@ -240,6 +240,8 @@ def parse_text_line(line: str, strict: bool = True) -> Dict[str, Any]
     'error': Exception | None,
 }
 ```
+
+経路ごとの型の詳細は [timestamp の型（経路別）](#timestamp-の型経路別) を参照する。
 
 **例外:**
 - `ValueError`: 文字列フォーマットが不正な場合（ERXDATAが見つからない等）
@@ -586,6 +588,7 @@ class VibrationSpeed(MurataSensorBase)
 - `Vibration2TF001AccelSensor`: 振動 2TF-001 加速度モード
 - `WaterproofContactPulseSensor`: 防水防塵接点パルスユニット (2ZS)
 - `WaterproofAnalogOutputSensor`: 防水防塵アナログ出力無線化ユニット (2ZU)
+- `ThermocoupleUnitSensor`: 熱電対ユニット (2PF)
 
 ---
 
@@ -627,6 +630,21 @@ class FailedCheckSumPayload(MurataExceptionBase)
 
 ## データ形式
 
+### timestamp の型（経路別）
+
+公開辞書の `timestamp` は経路によって型が異なる。1.x では次の契約を維持する。
+
+| 経路 | `timestamp` の型 | 意味 |
+|------|------------------|------|
+| UDP受信（`build_sensor_data`） | `str`（ISO8601） | 受信ホストの壁時計時刻 |
+| 未解析（`build_unparsed_data` デフォルト） | `str`（ISO8601） | 同上 |
+| `parse_text_line` 成功時 | `datetime \| None`（naive） | ログ行に記載された時刻（なければ `None`） |
+| `parse_text_line(..., strict=False)` 未解析 | `datetime \| str \| None` | ログ時刻が取れた場合は `datetime`、それ以外は生成時刻の `str` など |
+
+組み込み向けの正は ISO8601 文字列である。UDP / 未解析の辞書は標準の `json.dumps` でそのまま直列化できる。`parse_text_line` 成功時の `datetime` を JSON に含める場合は `.isoformat()` などで文字列化すること。
+
+2.0 候補: 公開辞書の `timestamp` をすべて ISO8601 `str` に揃える（`parse_text_line` 成功時の型変更を含む破壊的変更）。
+
 ### センサーデータ辞書
 
 `data_callback` / `AsyncMurataReceiver` のイテレーションで渡される解析済みデータの形式:
@@ -635,7 +653,7 @@ class FailedCheckSumPayload(MurataExceptionBase)
 {
     "sensor_type": "vibration",         # センサータイプ名
     "sensor_type_code": "09",           # センサ種別コード [tt]（16進2桁）
-    "timestamp": "2024-06-13T10:30:00", # ISO形式のタイムスタンプ
+    "timestamp": "2024-06-13T10:30:00", # 受信時刻（ISO8601文字列）
     "values": {                         # センサー値（キー毎に下記形式）
         "temperature": {
             "value": 25.3,
@@ -708,51 +726,62 @@ SENSOR_TYPE = {
     "030310FF": "current_pulse",            # 電流・パルス 1MU
     "030313FF": "voltage_pulse",            # 電圧・パルス 1RU
     "030312FF": "CT",                       # CT 1MT/1NT
-    
+
     # 振動センサー（加速度）
     "03030900": "vibration",                # 振動（加速度） 1LZ
     "03030901": "vibration",                # 振動（加速度）レンジオーバー 1LZ
-    
+
     # 振動センサー（速度）
     "03031800": "vibration_speed",          # 振動（速度） 1TF
     "03031801": "vibration_speed",          # 振動（速度）レンジオーバー 1TF
-    
+
     # 防水防塵対応ユニット
     "03031BFF": "3_current",                # 3電流 1ZU
     "03031CFF": "3_voltage",                # 3電圧 1ZV
-    "03031DFF": "3_contacts",               # 3接点 1ZS
+    "03031DFF": "3_contacts",               # 3接点 1ZS（イベント送信）
+    "03031D00": "3_contacts",               # 3接点 1ZS（定期送信）
     "03031EFF": "water_leak",               # 漏水センサ 2AX
-    
+
     # 中継機・監視ユニット
     "0303FEFF": "waterproof_repeater",      # 防水中継機 2CL
     "030319FF": "plg_duty",                 # PLG Duty比監視ユニット 2AU
-    "03032600": "brake_current_monitor",    # 無線ブレーキ電流監視ユニット 2DB
-    
+    "03032600": "brake_current_monitor",    # 無線ブレーキ電流監視ユニット 2DB（定期送信）
+    "030326FF": "brake_current_monitor",    # 無線ブレーキ電流監視ユニット 2DB（イベント送信）
+
     # 計測指示機能付振動センサー
     "03032B00": "vibration_with_instruction",  # 計測指示機能付無線振動センサユニット 2DN
     "03032B01": "vibration_with_instruction",  # 計測指示機能付無線振動センサユニット 2DN (レンジオーバー)
-    
+
     # 熱電対ユニット
     "030331FF": "compact_thermocouple",     # 小型熱電対ユニット 2FW
-    
+    "03033FFF": "thermocouple_unit",        # 熱電対ユニット 2PF（通常時）
+    "03033F02": "thermocouple_unit",        # 熱電対ユニット 2PF（無線異常）
+    "03033F03": "thermocouple_unit",        # 熱電対ユニット 2PF（センサ異常）
+
     # ソーラーユニット
     "03033AFF": "solar_external_sensor",    # 外部センサ用ソーラーユニット 2SL
-    "03033A00": "solar_external_sensor",    # 外部センサ用ソーラーユニット 2SL (接点パルスモード)
-    "03033A02": "solar_external_sensor",    # 外部センサ用ソーラーユニット 2SL (内部エラー)
-    
+    "03033A00": "solar_external_sensor",    # 外部センサ用ソーラーユニット 2SL（定期送信）
+    "03033A02": "solar_external_sensor",    # 外部センサ用ソーラーユニット 2SL（無線異常）
+    "03033A03": "solar_external_sensor",    # 外部センサ用ソーラーユニット 2SL（センサ異常）
+
     # 接点出力・メーター読取
     "030330FF": "contact_output",           # 接点出力ユニット 2ST
     "030333FF": "analog_meter_reader",      # アナログメーター読取ユニット 2YT
-    
+
     # 振動 2TF-001シリーズ
     "03032F00": "vibration_2tf001_speed",   # 振動 2TF-001（速度モード/低速回転モード）
     "03032F01": "vibration_2tf001_speed",   # 振動 2TF-001（速度モード）レンジオーバー
     "03033200": "vibration_2tf001_accel",   # 振動 2TF-001（加速度モード）
     "03033201": "vibration_2tf001_accel",   # 振動 2TF-001（加速度モード）レンジオーバー
-    
+
     # 防水防塵ユニット
-    "030338FF": "waterproof_contact_pulse", # 防水防塵接点パルスユニット 2ZS
-    "030339FF": "waterproof_analog_output", # 防水防塵アナログ出力無線化ユニット 2ZU
+    "030338FF": "waterproof_contact_pulse", # 防水防塵接点パルスユニット 2ZS（イベント送信）
+    "03033800": "waterproof_contact_pulse", # 防水防塵接点パルスユニット 2ZS（定期送信）
+    "03033802": "waterproof_contact_pulse", # 防水防塵接点パルスユニット 2ZS（無線異常）
+    "03033803": "waterproof_contact_pulse", # 防水防塵接点パルスユニット 2ZS（センサ異常）
+    "030339FF": "waterproof_analog_output", # 防水防塵アナログ出力無線化ユニット 2ZU（イベント送信）
+    "03033902": "waterproof_analog_output", # 防水防塵アナログ出力無線化ユニット 2ZU（無線異常）
+    "03033903": "waterproof_analog_output", # 防水防塵アナログ出力無線化ユニット 2ZU（センサ異常）
 }
 ```
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -3,7 +3,7 @@
 ## 基本情報
 
 - プロジェクト名: murata-sensor-receiver
-- 目的: 村田製作所製無線センサユニット（電文仕様G対応）からのUDPデータ受信・解析
+- 目的: 村田製作所製無線センサユニット（電文仕様K対応）からのUDPデータ受信・解析
 - ライセンス: MIT
 
 ## このライブラリについて
@@ -168,19 +168,20 @@ murata-sensor-receiver/
 | vibration_speed | 03031800, 03031801 | 振動センサー（速度） | 1TF | 未 |
 | 3_current | 03031BFF | 防水3電流センサー | 1ZU | 済み |
 | 3_voltage | 03031CFF | 防水3電圧センサー | 1ZV | 済み |
-| 3_contacts | 03031DFF | 防水3接点センサー | 1ZS | 済み |
+| 3_contacts | 03031DFF, 03031D00 | 防水3接点センサー | 1ZS | 済み |
 | water_leak | 03031EFF | 漏水センサー | 2AX | 未 |
 | waterproof_repeater | 0303FEFF | 防水中継機 | 2CL | 済み |
 | plg_duty | 030319FF | PLG Duty比監視ユニット | 2AU | 未 |
-| brake_current_monitor | 03032600 | 無線ブレーキ電流監視ユニット | 2DB | 未 |
+| brake_current_monitor | 03032600, 030326FF | 無線ブレーキ電流監視ユニット | 2DB | 未 |
 | vibration_with_instruction | 03032B00, 03032B01 | 計測指示機能付振動センサー | 2DN | 未 |
 | compact_thermocouple | 030331FF | 小型熱電対ユニット | 2FW | 未 |
-| solar_external_sensor | 03033AFF, 03033A00, 03033A02 | 外部センサ用ソーラーユニット | 2SL | 未 |
+| solar_external_sensor | 03033AFF, 03033A00, 03033A02, 03033A03 | 外部センサ用ソーラーユニット | 2SL | 未 |
 | contact_output | 030330FF | 接点出力ユニット | 2ST | 未 |
 | analog_meter_reader | 030333FF | アナログメーター読取ユニット | 2YT | 未 |
 | vibration_2tf001_speed | 03032F00, 03032F01 | 振動 2TF-001 速度モード/低速回転モード | 2TF-001 | 未 |
 | vibration_2tf001_accel | 03033200, 03033201 | 振動 2TF-001 加速度モード | 2TF-001 | 未 |
-| waterproof_contact_pulse | 030338FF | 防水防塵接点パルスユニット | 2ZS | 済み |
-| waterproof_analog_output | 030339FF | 防水防塵アナログ出力無線化ユニット | 2ZU | 済み |
+| waterproof_contact_pulse | 030338FF, 03033800, 03033802, 03033803 | 防水防塵接点パルスユニット | 2ZS | 済み |
+| waterproof_analog_output | 030339FF, 03033902, 03033903 | 防水防塵アナログ出力無線化ユニット | 2ZU | 済み |
+| thermocouple_unit | 03033FFF, 03033F02, 03033F03 | 熱電対ユニット | 2PF | 済み |
 
 対応済みセンサー一覧は `get_supported_sensors()` からも取得できる。詳細なAPIは [api_specification.md](api_specification.md) を参照。

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -101,7 +101,12 @@ asyncio.run(main())
 
 ## 変更履歴
 
-### v1.0.0 (現行)
+### v1.1.0 (現行)
+- **熱電対ユニット 2PF**: 電文仕様K対応（`thermocouple_unit` / `ThermocoupleUnitSensor`）
+- **状態コード**: 非振動センサーの `info.status` を仕様の状態表に合わせて更新
+- **ドキュメント**: 経路別 `timestamp` 型契約、2YT 単位表記、対応電文仕様Kの反映
+
+### v1.0.0
 - **メタデータAPI**: 対応センサー一覧・タイプ判定（`get_supported_sensors` 等）を追加
 - **解析検証フラグ**: `parse_verified` で実電文による値解析の自動テスト済み範囲を明示
 - **不具合修正**: Async の `sensor_type_code`、Solar 緯度経度の values 規約、振動系 SS 状態解析など

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "murata-sensor-receiver"
-version = "1.0.0"
+version = "1.1.0"
 authors = [
     {name = "Wazyc", email = "wazyc@example.com"},
 ]

--- a/src/murata_sensor/__init__.py
+++ b/src/murata_sensor/__init__.py
@@ -61,6 +61,7 @@ from .murata_sensor import (
     Vibration2TF001AccelSensor,
     WaterproofContactPulseSensor,
     WaterproofAnalogOutputSensor,
+    ThermocoupleUnitSensor,
     SENSOR_TYPE,
     UNIT_TYPE,
     get_supported_sensor_types,
@@ -109,6 +110,7 @@ __all__ = [
     "Vibration2TF001AccelSensor",
     "WaterproofContactPulseSensor",
     "WaterproofAnalogOutputSensor",
+    "ThermocoupleUnitSensor",
     # Constants
     "SENSOR_TYPE",
     "UNIT_TYPE",

--- a/src/murata_sensor/__init__.py
+++ b/src/murata_sensor/__init__.py
@@ -22,7 +22,7 @@ Text Line Parsing:
     print(result['values'])       # {'power-supply-voltage': {...}, ...}
 """
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 __author__ = "Murata Sensor Team"
 __email__ = "sensor-team@example.com"
 __license__ = "MIT"

--- a/src/murata_sensor/murata_receiver.py
+++ b/src/murata_sensor/murata_receiver.py
@@ -31,6 +31,7 @@ SENSOR_CLASSES = {
     "vibration_2tf001_accel": Vibration2TF001AccelSensor,
     "waterproof_contact_pulse": WaterproofContactPulseSensor,
     "waterproof_analog_output": WaterproofAnalogOutputSensor,
+    "thermocouple_unit": ThermocoupleUnitSensor,
 }
 
 

--- a/src/murata_sensor/murata_sensor.py
+++ b/src/murata_sensor/murata_sensor.py
@@ -18,25 +18,36 @@ SENSOR_TYPE = {
     "03031801": "vibration_speed",  # 振動（速度）レンジオーバー 1TF
     "03031BFF": "3_current",  # 3電流 1ZU
     "03031CFF": "3_voltage",  # 3電圧 1ZV
-    "03031DFF": "3_contacts",  # 3接点 1ZS
+    "03031DFF": "3_contacts",  # 3接点 1ZS（イベント送信）
+    "03031D00": "3_contacts",  # 3接点 1ZS（定期送信）
     "03031EFF": "water_leak",  # 漏水センサ 2AX
     "0303FEFF": "waterproof_repeater",  # 防水中継機 2CL
     "030319FF": "plg_duty",  # PLG Duty比監視ユニット 2AU
-    "03032600": "brake_current_monitor",  # 無線ブレーキ電流監視ユニット 2DB
+    "03032600": "brake_current_monitor",  # 無線ブレーキ電流監視ユニット 2DB（定期送信）
+    "030326FF": "brake_current_monitor",  # 無線ブレーキ電流監視ユニット 2DB（イベント送信）
     "03032B00": "vibration_with_instruction",  # 計測指示機能付無線振動センサユニット 2DN
     "03032B01": "vibration_with_instruction",  # 計測指示機能付無線振動センサユニット 2DN (レンジオーバー)
     "030331FF": "compact_thermocouple",  # 小型熱電対ユニット 2FW
     "03033AFF": "solar_external_sensor",  # 外部センサ用ソーラーユニット 2SL
-    "03033A00": "solar_external_sensor",  # 外部センサ用ソーラーユニット 2SL (接点パルスモード)
-    "03033A02": "solar_external_sensor",  # 外部センサ用ソーラーユニット 2SL (内部エラー)
+    "03033A00": "solar_external_sensor",  # 外部センサ用ソーラーユニット 2SL（定期送信）
+    "03033A02": "solar_external_sensor",  # 外部センサ用ソーラーユニット 2SL（無線異常）
+    "03033A03": "solar_external_sensor",  # 外部センサ用ソーラーユニット 2SL（センサ異常）
     "030330FF": "contact_output",  # 接点出力ユニット 2ST
     "030333FF": "analog_meter_reader",  # アナログメーター読取ユニット 2YT
     "03032F00": "vibration_2tf001_speed",  # 振動 2TF-001（速度モード/低速回転モード）
     "03032F01": "vibration_2tf001_speed",  # 振動 2TF-001（速度モード）レンジオーバー
     "03033200": "vibration_2tf001_accel",  # 振動 2TF-001（加速度モード）
     "03033201": "vibration_2tf001_accel",  # 振動 2TF-001（加速度モード）レンジオーバー
-    "030338FF": "waterproof_contact_pulse",  # 防水防塵接点パルスユニット 2ZS
-    "030339FF": "waterproof_analog_output",  # 防水防塵アナログ出力無線化ユニット 2ZU
+    "030338FF": "waterproof_contact_pulse",  # 防水防塵接点パルスユニット 2ZS（イベント送信）
+    "03033800": "waterproof_contact_pulse",  # 防水防塵接点パルスユニット 2ZS（定期送信）
+    "03033802": "waterproof_contact_pulse",  # 防水防塵接点パルスユニット 2ZS（無線異常）
+    "03033803": "waterproof_contact_pulse",  # 防水防塵接点パルスユニット 2ZS（センサ異常）
+    "030339FF": "waterproof_analog_output",  # 防水防塵アナログ出力無線化ユニット 2ZU（イベント送信）
+    "03033902": "waterproof_analog_output",  # 防水防塵アナログ出力無線化ユニット 2ZU（無線異常）
+    "03033903": "waterproof_analog_output",  # 防水防塵アナログ出力無線化ユニット 2ZU（センサ異常）
+    "03033FFF": "thermocouple_unit",  # 熱電対ユニット 2PF（通常時）
+    "03033F02": "thermocouple_unit",  # 熱電対ユニット 2PF（無線異常）
+    "03033F03": "thermocouple_unit",  # 熱電対ユニット 2PF（センサ異常）
 }
 
 # 対応センサー一覧APIで返す補助情報。
@@ -159,6 +170,11 @@ SENSOR_METADATA = {
     "waterproof_analog_output": {
         "description": "防水防塵アナログ出力無線化ユニット",
         "products": ("2ZU",),
+        "parse_verified": True,
+    },
+    "thermocouple_unit": {
+        "description": "熱電対ユニット",
+        "products": ("2PF",),
         "parse_verified": True,
     },
 }
@@ -417,11 +433,18 @@ class MurataSensorBase(object):
                 "code": status,
                 "description": "正常" if status == "00" else "レンジオーバー",
             }
-        else:
-            return {
-                "code": status,
-                "description": "固定値(FF)" if status == "FF" else "不明な状態",
-            }
+
+        # 共通状態表: 00=正常, 02=無線異常, 03=センサ異常, FF=RFU
+        status_descriptions = {
+            "00": "正常",
+            "02": "無線異常",
+            "03": "センサ異常",
+            "FF": "RFU",
+        }
+        return {
+            "code": status,
+            "description": status_descriptions.get(status, "不明な状態"),
+        }
 
     def _get_value(self, val_hex_text: bytes) -> Dict[str, Any]:
         """ペイロード内の個別のデータを返す
@@ -1041,6 +1064,15 @@ class ContactOutputSensor(MurataSensorBase):
 class AnalogMeterReaderSensor(MurataSensorBase):
     """アナログメーター読取ユニット 2YT"""
 
+    @staticmethod
+    def _as_unitless(value: Dict[str, Any]) -> Dict[str, Any]:
+        """単位コード0Bでも意味上は単位なしの項目向けにunitを上書きする"""
+        return {
+            "value": value["value"],
+            "unit": "-",
+            "unit_name": "単位なし",
+        }
+
     def retrieve_values(self) -> None:
         # 電源電圧：[V]
         self.values["power-supply-voltage"] = self._get_value(self.payload[8:16])
@@ -1050,22 +1082,34 @@ class AnalogMeterReaderSensor(MurataSensorBase):
         self.info["serial_number"] = serial_upper + serial_lower
         # CH1角度：[deg]
         self.values["ch1-angle"] = self._get_value(self.payload[32:40])
-        # CH1角度(Min)：[deg]
-        self.values["ch1-angle-min"] = self._get_value(self.payload[40:48])
-        # CH1角度(Max)：[deg]
-        self.values["ch1-angle-max"] = self._get_value(self.payload[48:56])
-        # CH1補正値：[deg]
-        self.values["ch1-correction"] = self._get_value(self.payload[56:64])
+        # CH1角度(Min)：[-]（単位コードは0Bだが意味上は単位なし）
+        self.values["ch1-angle-min"] = self._as_unitless(
+            self._get_value(self.payload[40:48])
+        )
+        # CH1角度(Max)：[-]
+        self.values["ch1-angle-max"] = self._as_unitless(
+            self._get_value(self.payload[48:56])
+        )
+        # CH1補正値：[-]
+        self.values["ch1-correction"] = self._as_unitless(
+            self._get_value(self.payload[56:64])
+        )
         # CH1磁力強度：[-]
         self.values["ch1-magnetic-strength"] = self._get_value(self.payload[64:72])
         # CH2角度：[deg]
         self.values["ch2-angle"] = self._get_value(self.payload[72:80])
-        # CH2角度(Min)：[deg]
-        self.values["ch2-angle-min"] = self._get_value(self.payload[80:88])
-        # CH2角度(Max)：[deg]
-        self.values["ch2-angle-max"] = self._get_value(self.payload[88:96])
-        # CH2補正値：[deg]
-        self.values["ch2-correction"] = self._get_value(self.payload[96:104])
+        # CH2角度(Min)：[-]
+        self.values["ch2-angle-min"] = self._as_unitless(
+            self._get_value(self.payload[80:88])
+        )
+        # CH2角度(Max)：[-]
+        self.values["ch2-angle-max"] = self._as_unitless(
+            self._get_value(self.payload[88:96])
+        )
+        # CH2補正値：[-]
+        self.values["ch2-correction"] = self._as_unitless(
+            self._get_value(self.payload[96:104])
+        )
         # CH2磁力強度：[-]
         self.values["ch2-magnetic-strength"] = self._get_value(self.payload[104:112])
 
@@ -1202,3 +1246,31 @@ class WaterproofAnalogOutputSensor(MurataSensorBase):
         self.values["voltage3"] = self._get_value(self.payload[72:80])
         # 測定モード
         self.values["measurement-mode"] = self._get_value(self.payload[80:88])
+
+
+class ThermocoupleUnitSensor(MurataSensorBase):
+    """熱電対ユニット 2PF
+
+    熱電対タイプの値（単位なし）:
+    0=K型, 1=J型, 2=T型, 7=R型
+    """
+
+    def retrieve_values(self) -> None:
+        # 電源電圧：[V]
+        self.values["power-supply-voltage"] = self._get_value(self.payload[8:16])
+        # シリアルナンバー
+        serial_upper = self.payload[16:24].decode()
+        serial_lower = self.payload[24:32].decode()
+        self.info["serial_number"] = serial_upper + serial_lower
+        # CH1熱電対タイプ：[-]（0=K, 1=J, 2=T, 7=R）
+        self.values["ch1-thermocouple-type"] = self._get_value(self.payload[32:40])
+        # CH1温度：[℃]
+        self.values["ch1-temperature"] = self._get_value(self.payload[40:48])
+        # CH2熱電対タイプ：[-]
+        self.values["ch2-thermocouple-type"] = self._get_value(self.payload[48:56])
+        # CH2温度：[℃]
+        self.values["ch2-temperature"] = self._get_value(self.payload[56:64])
+        # CH3熱電対タイプ：[-]
+        self.values["ch3-thermocouple-type"] = self._get_value(self.payload[64:72])
+        # CH3温度：[℃]
+        self.values["ch3-temperature"] = self._get_value(self.payload[72:80])

--- a/tests/test_murata_sensor.py
+++ b/tests/test_murata_sensor.py
@@ -1024,7 +1024,8 @@ class TestAdditionalSensorTypes:
             "vibration_with_instruction", "compact_thermocouple",
             "solar_external_sensor", "contact_output", "analog_meter_reader",
             "vibration_2tf001_speed", "vibration_2tf001_accel",
-            "waterproof_contact_pulse", "waterproof_analog_output"
+            "waterproof_contact_pulse", "waterproof_analog_output",
+            "thermocouple_unit",
         ]
 
         for sensor_type in expected_sensor_types:
@@ -1053,6 +1054,13 @@ class TestAdditionalSensorTypes:
             "03033AFF",
             "03033A00",
             "03033A02",
+            "03033A03",
+        )
+        assert sensors["3_contacts"]["type_codes"] == ("03031DFF", "03031D00")
+        assert sensors["thermocouple_unit"]["type_codes"] == (
+            "03033FFF",
+            "03033F02",
+            "03033F03",
         )
 
     def test_get_supported_sensor_types_matches_receiver_classes(self):
@@ -1108,6 +1116,7 @@ class TestAdditionalSensorTypes:
             "waterproof_repeater",
             "waterproof_contact_pulse",
             "waterproof_analog_output",
+            "thermocouple_unit",
         }
 
 
@@ -1268,13 +1277,58 @@ class TestEdgeCases:
         assert sensor.payload_length == 32
 
     def test_sensor_status_unknown(self):
-        """未知のセンサー状態コードのテスト"""
+        """RFU（FF）のセンサー状態コードのテスト"""
         addr = ("192.168.1.100", 1234)
         data = b"ERXDATA 0002 0000 62BE F000 18 20 030301FF012605320C90052A11AF052C7C0002 7FFF"
         sensor = TemperatureAndHumiditySensor(data, addr)
 
-        # 温湿度センサーのステータスコードはFF
-        assert sensor.info['status']['code'] == 'FF'
+        # 温湿度センサーのステータスコードはFF（RFU）
+        assert sensor.info["status"]["code"] == "FF"
+        assert sensor.info["status"]["description"] == "RFU"
+
+    def test_non_vibration_status_parsing(self):
+        """非振動センサーの共通状態コード解析"""
+        addr = ("192.168.1.100", 1234)
+        cases = [
+            (b"03031D00", "3_contacts", "00", "正常"),
+            (b"03031DFF", "3_contacts", "FF", "RFU"),
+            (b"03033802", "waterproof_contact_pulse", "02", "無線異常"),
+            (b"03033903", "waterproof_analog_output", "03", "センサ異常"),
+            (b"03033A03", "solar_external_sensor", "03", "センサ異常"),
+            (b"03033F02", "thermocouple_unit", "02", "無線異常"),
+        ]
+        from murata_sensor.murata_receiver import SENSOR_CLASSES
+
+        for type_code, sensor_type, code, description in cases:
+            cls = SENSOR_CLASSES[sensor_type]
+            with patch.object(cls, "retrieve_values", lambda self: None):
+                sensor = cls(_vibration_packet_with_type_code(type_code), addr)
+            assert sensor.check_sensor_type(sensor.data) == sensor_type
+            assert sensor.info["status"] == {
+                "code": code,
+                "description": description,
+            }, type_code.decode()
+
+    def test_added_ss_codes_resolve_to_sensor_type(self):
+        """仕様Kで追記したSS変種が同一センサータイプに解決されること"""
+        cases = [
+            (b"03031D00", "3_contacts"),
+            (b"030326FF", "brake_current_monitor"),
+            (b"03033A03", "solar_external_sensor"),
+            (b"03033800", "waterproof_contact_pulse"),
+            (b"03033802", "waterproof_contact_pulse"),
+            (b"03033803", "waterproof_contact_pulse"),
+            (b"03033902", "waterproof_analog_output"),
+            (b"03033903", "waterproof_analog_output"),
+            (b"03033FFF", "thermocouple_unit"),
+            (b"03033F02", "thermocouple_unit"),
+            (b"03033F03", "thermocouple_unit"),
+        ]
+        for type_code, sensor_type in cases:
+            data = _vibration_packet_with_type_code(type_code)
+            assert MurataSensorBase.check_sensor_type(data) == sensor_type, (
+                type_code.decode()
+            )
 
     def test_vibration_sensor_range_over_status(self):
         """振動センサー実電文で SS=01 がレンジオーバーになること"""
@@ -1745,3 +1799,87 @@ class TestWaterproofAnalogOutputSensor:
         """WaterproofAnalogOutputSensorクラスの構造テスト"""
         assert hasattr(WaterproofAnalogOutputSensor, "retrieve_values")
         assert issubclass(WaterproofAnalogOutputSensor, MurataSensorBase)
+
+
+class TestThermocoupleUnitSensor:
+    """熱電対ユニット 2PF のテスト"""
+
+    SAMPLE = (
+        b"ERXDATA D7EE 0000 63C7 F000 53 52 "
+        b"03033FFF01430532000610FA13D7EEFA0000006800EC042A0001006800EE042A"
+        b"00070068FFFFFF2A7C02 D7EE 7FFF"
+    )
+
+    def test_check_sensor_type(self):
+        """センサータイプの識別テスト"""
+        assert MurataSensorBase.check_sensor_type(self.SAMPLE) == "thermocouple_unit"
+
+    def test_create_sensor(self):
+        """create_sensor で ThermocoupleUnitSensor が生成されることを確認"""
+        addr = ("192.168.1.100", 55039)
+        sensor = create_sensor(self.SAMPLE, addr)
+        assert sensor is not None
+        assert isinstance(sensor, ThermocoupleUnitSensor)
+
+    def test_sensor_values(self):
+        """センサー値の解析テスト（仕様書サンプル電文）"""
+        addr = ("192.168.1.100", 55039)
+        sensor = ThermocoupleUnitSensor(self.SAMPLE, addr)
+
+        assert sensor.info["unit_id"] == "D7EE"
+        assert sensor.info["serial_number"] == "000610FA13D7EEFA"
+        assert sensor.info["status"] == {"code": "FF", "description": "RFU"}
+
+        # 電源電圧：0143 (323) × 0.01 = 3.23V
+        assert sensor.values["power-supply-voltage"]["value"] == 3.23
+        assert sensor.values["power-supply-voltage"]["unit"] == "V"
+
+        # 熱電対タイプ: 0=K, 1=J, 7=R
+        assert sensor.values["ch1-thermocouple-type"]["value"] == 0
+        assert sensor.values["ch2-thermocouple-type"]["value"] == 1
+        assert sensor.values["ch3-thermocouple-type"]["value"] == 7
+
+        # 温度: 23.6 / 23.8 / 無効
+        assert sensor.values["ch1-temperature"]["value"] == 23.6
+        assert sensor.values["ch1-temperature"]["unit"] == "℃"
+        assert sensor.values["ch2-temperature"]["value"] == 23.8
+        assert sensor.values["ch3-temperature"]["value"] is None
+
+    def test_sensor_class_structure(self):
+        """ThermocoupleUnitSensorクラスの構造テスト"""
+        assert hasattr(ThermocoupleUnitSensor, "retrieve_values")
+        assert issubclass(ThermocoupleUnitSensor, MurataSensorBase)
+
+
+class TestAnalogMeterReaderUnits:
+    """アナログメーター読取ユニット 2YT の単位訂正テスト"""
+
+    SAMPLE = (
+        b"ERXDATA FF99 0000 418C F000 52 72 "
+        b"030333FF012A0532000610FA12FF99FA0047000B0047000B0047000B002C000B"
+        b"029200610047000B0047000B0047000B002C000B029200617202 FF99 7FFF"
+    )
+
+    def test_unitless_fields_override(self):
+        """角度(Min/Max)と補正値の単位が単位なしになること"""
+        data = _rebuild_packet_checksums(bytearray(self.SAMPLE))
+        addr = ("192.168.1.100", 55039)
+        sensor = AnalogMeterReaderSensor(data, addr)
+
+        assert sensor.values["ch1-angle"]["unit"] == "deg"
+        assert sensor.values["ch1-angle"]["value"] == 71
+        for key in (
+            "ch1-angle-min",
+            "ch1-angle-max",
+            "ch1-correction",
+            "ch2-angle-min",
+            "ch2-angle-max",
+            "ch2-correction",
+        ):
+            assert sensor.values[key]["unit"] == "-", key
+            assert sensor.values[key]["unit_name"] == "単位なし", key
+            assert sensor.values[key]["value"] is not None, key
+
+        assert sensor.values["ch2-angle"]["unit"] == "deg"
+        assert sensor.values["ch1-magnetic-strength"]["unit"] == "-"
+

--- a/tests/test_murata_sensor.py
+++ b/tests/test_murata_sensor.py
@@ -1882,4 +1882,3 @@ class TestAnalogMeterReaderUnits:
 
         assert sensor.values["ch2-angle"]["unit"] == "deg"
         assert sensor.values["ch1-magnetic-strength"]["unit"] == "-"
-


### PR DESCRIPTION
## Summary
- Prepare for release v1.1.0 (version bump, CHANGELOG, overview)
- Includes thermocouple unit 2PF support and related docs/status updates from 30e1bdd

## Test plan
- [x] pytest 145 passed
- [x] `python -m build` + `twine check` PASSED
- [ ] Merge this PR, then push tag `v1.1.0` on the merge commit if needed
- [ ] Manual PyPI upload of `dist/murata_sensor_receiver-1.1.0*`


Made with [Cursor](https://cursor.com)